### PR TITLE
remove overwrite of url by mistake

### DIFF
--- a/mofi/mofi/Modules/Search/DataManager/SearchAPIDataManager.swift
+++ b/mofi/mofi/Modules/Search/DataManager/SearchAPIDataManager.swift
@@ -10,12 +10,12 @@ import Foundation
 final class SearchAPIDataManager: SearchAPIDataManagerProtocol {
     
     private let dataRetriever = URLDataRetriever()
-    private var url = "http://www.omdbapi.com/?"
+    private var site = "http://www.omdbapi.com/?"
     private var apikey = "&apikey=ffe6baf4"
     
     //user types
     func requestMoviesTitle(input: String, resultBlock: @escaping APIDataManagerMovieResultBlock) {
-        url = url + "s=" + input + apikey
+        let url = site + "s=" + input + apikey
         self.dataRetriever.retrieve(url: url) { (result: APIDataManagerMovieResult) in
             resultBlock(result)
         }
@@ -23,7 +23,7 @@ final class SearchAPIDataManager: SearchAPIDataManagerProtocol {
     
     //user chooses one movie from the list
     func requestMovieDetail(movieId: String, resultBlock: @escaping APIDataManagerMovieDetailResultBlock) {
-        url = url + "i=" + movieId + apikey
+        let url = site + "i=" + movieId + apikey
         self.dataRetriever.retrieve(url: url) { (result: APIDataManagerMovieDetailResult) in
             resultBlock(result)
         }


### PR DESCRIPTION
i thought the fact that only the first search worked was a limitation of the api but instead it was a silly overwrite of a variable. mb